### PR TITLE
feat: Supports dynamic blocks in replication_specs

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -414,7 +414,7 @@ func getSpecs(configSrc *hclwrite.Block, countName string, root attrVals, isDyna
 	}
 	tokens := hcl.TokensObject(fileb)
 	if isDynamicBlock {
-		tokens = encloseDynamicBlockRegionSpec(tokens, countName)
+		tokens = append(hcl.TokensFromExpr(fmt.Sprintf("%s.%s == 0 ? null :", nRegion, countName)), tokens...)
 	}
 	return tokens, nil
 }
@@ -518,12 +518,6 @@ func getDynamicBlock(body *hclwrite.Body, name string) (dynamicBlock, error) {
 func replaceDynamicBlockExpr(attr *hclwrite.Attribute, blockName, attrName string) string {
 	expr := hcl.GetAttrExpr(attr)
 	return strings.ReplaceAll(expr, fmt.Sprintf("%s.%s", blockName, attrName), attrName)
-}
-
-func encloseDynamicBlockRegionSpec(specTokens hclwrite.Tokens, countName string) hclwrite.Tokens {
-	tokens := hcl.TokensFromExpr(fmt.Sprintf("%s.%s > 0 ?", nRegion, countName))
-	tokens = append(tokens, specTokens...)
-	return append(tokens, hcl.TokensFromExpr(": null")...)
 }
 
 // getDynamicBlockRegionConfigsRegionArray returns the region array for a dynamic block in replication_specs.

--- a/internal/convert/testdata/clu2adv/dynamic_regions_config_auto_scaling.out.tf
+++ b/internal/convert/testdata/clu2adv/dynamic_regions_config_auto_scaling.out.tf
@@ -23,27 +23,27 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
             provider_name = var.provider_name
             region_name   = region.region_name
             priority      = region.priority
-            electable_specs = region.electable_nodes > 0 ? {
+            electable_specs = region.electable_nodes == 0 ? null : {
               node_count      = region.electable_nodes
               instance_size   = var.provider_instance_size_name
               disk_size_gb    = var.disk_size_gb
               ebs_volume_type = var.provider_volume_type
               disk_iops       = var.provider_disk_iops
-            } : null
-            read_only_specs = region.read_only_nodes > 0 ? {
+            }
+            read_only_specs = region.read_only_nodes == 0 ? null : {
               node_count      = region.read_only_nodes
               instance_size   = var.provider_instance_size_name
               disk_size_gb    = var.disk_size_gb
               ebs_volume_type = var.provider_volume_type
               disk_iops       = var.provider_disk_iops
-            } : null
-            analytics_specs = region.analytics_nodes > 0 ? {
+            }
+            analytics_specs = region.analytics_nodes == 0 ? null : {
               node_count      = region.analytics_nodes
               instance_size   = var.provider_instance_size_name
               disk_size_gb    = var.disk_size_gb
               ebs_volume_type = var.provider_volume_type
               disk_iops       = var.provider_disk_iops
-            } : null
+            }
             auto_scaling = {
               disk_gb_enabled = var.auto_scaling_disk_gb_enabled
             }

--- a/internal/convert/testdata/clu2adv/dynamic_regions_config_basic.out.tf
+++ b/internal/convert/testdata/clu2adv/dynamic_regions_config_basic.out.tf
@@ -12,14 +12,14 @@ resource "mongodbatlas_advanced_cluster" "dynamic_regions_config" {
             provider_name = "AWS"
             region_name   = region.region_name
             priority      = region.prio
-            electable_specs = region.electable_nodes > 0 ? {
+            electable_specs = region.electable_nodes == 0 ? null : {
               node_count    = region.electable_nodes
               instance_size = "M10"
-            } : null
-            read_only_specs = region.read_only_nodes > 0 ? {
+            }
+            read_only_specs = region.read_only_nodes == 0 ? null : {
               node_count    = region.read_only_nodes
               instance_size = "M10"
-            } : null
+            }
           } if priority == region.prio
         ]
       ])


### PR DESCRIPTION
## Description

Supports dynamic blocks in replication_specs.

Link to any related issue(s): CLOUDP-303941

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
