### PR TITLE
chore: Removes reviewers field in the dependabot.yml as it is being removed in favor of CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: tuesday
     commit-message:
       prefix: "chore"
-    reviewers:
-      - "mongodb-labs/apix-integrations"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -16,5 +14,3 @@ updates:
       day: tuesday
     commit-message:
       prefix: "chore"
-    reviewers:
-      - "mongodb-labs/apix-integrations"


### PR DESCRIPTION
## Description

 Removes reviewers field in the dependabot.yml as it is being removed in favor of CODEOWNERS

Link to any related issue(s): https://github.com/mongodb-labs/atlas-cli-plugin-terraform/pull/47#issuecomment-2895851981

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
