### PR TITLE
feat: Convert from blocks to nested attributes in advancedClusterToV2 command

### DIFF
--- a/internal/cli/clu2adv/clu2adv.go
+++ b/internal/cli/clu2adv/clu2adv.go
@@ -10,10 +10,10 @@ import (
 
 func Builder() *cobra.Command {
 	o := &struct {
-		*cli.BaseOpts
+		cli.BaseOpts
 		includeMoved bool
 	}{
-		BaseOpts: &cli.BaseOpts{
+		BaseOpts: cli.BaseOpts{
 			Fs: afero.NewOsFs(),
 		},
 	}
@@ -28,7 +28,7 @@ func Builder() *cobra.Command {
 		Aliases: []string{"clu2adv"},
 		RunE:    o.RunE,
 	}
-	cli.SetupCommonFlags(cmd, o.BaseOpts)
+	cli.SetupCommonFlags(cmd, &o.BaseOpts)
 	cmd.Flags().BoolVarP(&o.includeMoved, flag.IncludeMoved, flag.IncludeMovedShort, false,
 		"include moved blocks in the output file")
 	return cmd

--- a/internal/convert/testdata/adv2v2/basic.in.tf
+++ b/internal/convert/testdata/adv2v2/basic.in.tf
@@ -1,4 +1,16 @@
-resource "mongodbatlas_advanced_cluster" "basic" {
-  name = "basic"
-  // TODO: missing fields as transformation is not implemented yet
+resource "mongodbatlas_advanced_cluster" "clu" {
+  project_id   = "66d979971ec97b7de1ef8777"
+  name         = "clu"
+  cluster_type = "REPLICASET"
+  replication_specs {
+    region_configs {
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "EU_WEST_1"
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }
+  }
 }

--- a/internal/convert/testdata/adv2v2/basic.out.tf
+++ b/internal/convert/testdata/adv2v2/basic.out.tf
@@ -1,4 +1,22 @@
-resource "mongodbatlas_advanced_cluster" "basic" {
-  name = "basic"
-  // TODO: missing fields as transformation is not implemented yet
+resource "mongodbatlas_advanced_cluster" "clu" {
+  project_id   = "66d979971ec97b7de1ef8777"
+  name         = "clu"
+  cluster_type = "REPLICASET"
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          priority      = 7
+          provider_name = "AWS"
+          region_name   = "EU_WEST_1"
+          electable_specs = {
+            node_count    = 3
+            instance_size = "M10"
+          }
+        }
+      ]
+    }
+  ]
+
+  # Updated by atlas-cli-plugin-terraform, please review the changes.
 }


### PR DESCRIPTION
## Description

Convert from blocks to nested attributes in advancedClusterToV2 command

Link to any related issue(s): CLOUDP-337883

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
