### PR TITLE
feat: Support region_configs without dynamic block inside a replication_specs with dynamic blocks

### DIFF
--- a/docs/command_adv2v2.md
+++ b/docs/command_adv2v2.md
@@ -56,6 +56,7 @@ dynamic "tags" {
 ### Dynamic blocks in region_configs
 
 You can use `dynamic` blocks for `region_configs`. The plugin assumes that the value of `for_each` is an expression which evaluates to a `list` of objects.
+**Note:** `map` and `set` are not supported.
 
 This is an example of how to use dynamic blocks in `region_configs`:
 ```hcl
@@ -81,6 +82,7 @@ replication_specs {
 ### Dynamic blocks in replication_specs
 
 You can use `dynamic` blocks for `replication_specs`. The plugin assumes that the value of `for_each` is an expression which evaluates to a `list` of objects.
+**Note:** `map` and `set` are not supported.
 
 This is an example of how to use dynamic blocks in `replication_specs`:
 ```hcl

--- a/docs/command_clu2adv.md
+++ b/docs/command_clu2adv.md
@@ -56,6 +56,7 @@ dynamic "tags" {
 ### Dynamic blocks in regions_config
 
 You can use `dynamic` blocks for `regions_config`. The plugin assumes that the value of `for_each` is an expression which evaluates to a `list` of objects.
+**Note:** `map` and `set` are not supported.
 
 This is an example of how to use dynamic blocks in `regions_config`:
 ```hcl
@@ -77,6 +78,7 @@ replication_specs {
 ### Dynamic blocks in replication_specs
 
 You can use `dynamic` blocks for `replication_specs`. The plugin assumes that the value of `for_each` is an expression which evaluates to a `list` of objects.
+**Note:** `map` and `set` are not supported.
 
 This is an example of how to use dynamic blocks in `replication_specs`:
 ```hcl

--- a/internal/convert/testdata/adv2v2/dynamic_replication_specs_no_dynamic_region_configs.in.tf
+++ b/internal/convert/testdata/adv2v2/dynamic_replication_specs_no_dynamic_region_configs.in.tf
@@ -1,0 +1,82 @@
+locals {
+  replication_specs_list = [
+    {
+      zone_name   = "zone1"
+      region_name = "US_EAST_1"
+    },
+    {
+      zone_name   = "zone2"
+      region_name = "US_WEST_2"
+    }
+  ]
+}
+
+resource "mongodbatlas_advanced_cluster" "one_config" {
+  project_id   = "123"
+  name         = "cluster"
+  cluster_type = "SHARDED"
+
+  dynamic "replication_specs" {
+    for_each = local.replication_specs_list
+    content {
+      num_shards = 2
+      zone_name  = replication_specs.value.zone_name
+
+      region_configs {
+        provider_name = "AWS"
+        region_name   = replication_specs.value.region_name
+        priority      = 7
+
+        electable_specs {
+          instance_size = "M10"
+          node_count    = 3
+        }
+        auto_scaling {
+          disk_gb_enabled = true
+        }
+      }
+    }
+  }
+}
+
+resource "mongodbatlas_advanced_cluster" "multiple_config" {
+  project_id   = "123"
+  name         = "cluster"
+  cluster_type = "SHARDED"
+
+  dynamic "replication_specs" {
+    for_each = local.replication_specs_list
+    content {
+      num_shards = 2
+      zone_name  = replication_specs.value.zone_name
+
+      region_configs {
+        provider_name = "AWS"
+        region_name   = replication_specs.value.region_name
+        priority      = 7
+
+        electable_specs {
+          instance_size = "M10"
+          node_count    = 2
+        }
+        auto_scaling {
+          disk_gb_enabled = true
+        }
+      }
+
+      region_configs {
+        provider_name = "AWS"
+        region_name   = replication_specs.value.region_name
+        priority      = 6
+
+        electable_specs {
+          instance_size = "M10"
+          node_count    = 1
+        }
+        auto_scaling {
+          disk_gb_enabled = true
+        }
+      }
+    }
+  }
+}

--- a/internal/convert/testdata/adv2v2/dynamic_replication_specs_no_dynamic_region_configs.out.tf
+++ b/internal/convert/testdata/adv2v2/dynamic_replication_specs_no_dynamic_region_configs.out.tf
@@ -1,0 +1,84 @@
+locals {
+  replication_specs_list = [
+    {
+      zone_name   = "zone1"
+      region_name = "US_EAST_1"
+    },
+    {
+      zone_name   = "zone2"
+      region_name = "US_WEST_2"
+    }
+  ]
+}
+
+resource "mongodbatlas_advanced_cluster" "one_config" {
+  project_id   = "123"
+  name         = "cluster"
+  cluster_type = "SHARDED"
+
+  replication_specs = flatten([
+    for spec in local.replication_specs_list : [
+      for i in range(2) : {
+        zone_name = spec.zone_name
+        region_configs = [
+          {
+            priority      = 7
+            provider_name = "AWS"
+            region_name   = spec.region_name
+            electable_specs = {
+              instance_size = "M10"
+              node_count    = 3
+            }
+            auto_scaling = {
+              disk_gb_enabled = true
+            }
+          }
+        ]
+      }
+    ]
+  ])
+
+  # Updated by atlas-cli-plugin-terraform, please review the changes.
+}
+
+resource "mongodbatlas_advanced_cluster" "multiple_config" {
+  project_id   = "123"
+  name         = "cluster"
+  cluster_type = "SHARDED"
+
+  replication_specs = flatten([
+    for spec in local.replication_specs_list : [
+      for i in range(2) : {
+        zone_name = spec.zone_name
+        region_configs = [
+          {
+            priority      = 7
+            provider_name = "AWS"
+            region_name   = spec.region_name
+            electable_specs = {
+              instance_size = "M10"
+              node_count    = 2
+            }
+            auto_scaling = {
+              disk_gb_enabled = true
+            }
+          },
+          {
+            priority      = 6
+            provider_name = "AWS"
+            region_name   = spec.region_name
+            electable_specs = {
+              instance_size = "M10"
+              node_count    = 1
+            }
+            auto_scaling = {
+              disk_gb_enabled = true
+            }
+          }
+        ]
+      }
+    ]
+  ])
+
+  # Updated by atlas-cli-plugin-terraform, please review the changes.
+}


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
