### PR TITLE
chore: Add explicit permissions to release, stale and issues workflows

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,6 +4,10 @@
   on:
     issues:
       types: [opened, reopened, closed]
+
+  permissions:
+    issues: write
+
   jobs:
     jira_task:
       name: Create Jira issue

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,8 @@ jobs:
   compliance:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
@@ -95,6 +97,8 @@ jobs:
   generate-ssdlc-report:
     needs: compliance
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: terraform-provider-mongodbatlas-checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Addresses the 6 open CodeQL `actions/missing-workflow-permissions` alerts ([code scanning](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/security/code-scanning?query=is%3Aopen)) by adding explicit least-privilege `permissions` blocks:

- `release.yml` / `compliance`: `contents: write` (uploads the SBOM as a release artifact with `GITHUB_TOKEN`).
- `release.yml` / `generate-ssdlc-report`: `contents: read` (checkout only; the SSDLC report commit is pushed via the APIx bot PAT, not the workflow token).
- `stale.yml`: workflow-level `contents: read, issues: write, pull-requests: write`, mirroring the equivalent workflow in mongodb/terraform-provider-mongodbatlas.
- `issues.yml`: workflow-level `issues: write` (needed by `peter-evans/create-or-update-comment`, which defaults to the workflow token), also mirroring mongodb/terraform-provider-mongodbatlas.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb-labs/atlas-cli-plugin-terraform/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
